### PR TITLE
DATA-4655 Kafka-connect-jdbc fork to include default values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
             <id>confluent</id>
             <name>Confluent</name>
             <url>${confluent.maven.repo}</url>
-            <snapshots><enabled>false</enabled></snapshots>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <confluent.version>${project.version}</confluent.version>
-        <kafka.version>0.11.0.0-cp1</kafka.version>
+        <kafka.version>0.11.0.0</kafka.version>
         <junit.version>4.12</junit.version>
         <easymock.version>3.0</easymock.version>
         <powermock.version>1.6.2</powermock.version>
@@ -71,6 +71,7 @@
             <id>confluent</id>
             <name>Confluent</name>
             <url>${confluent.maven.repo}</url>
+            <snapshots><enabled>false</enabled></snapshots>
         </repository>
     </repositories>
 

--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -35,6 +35,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Types;
+import java.util.Map;
 
 import io.confluent.connect.jdbc.util.DateTimeUtils;
 
@@ -45,12 +46,13 @@ import io.confluent.connect.jdbc.util.DateTimeUtils;
 public class DataConverter {
   private static final Logger log = LoggerFactory.getLogger(JdbcSourceTask.class);
 
-  public static Schema convertSchema(String tableName, ResultSetMetaData metadata, boolean mapNumerics)
+  public static Schema convertSchema(String tableName, ResultSetMetaData metadata, Map<String, String> columnDefaults, boolean mapNumerics)
       throws SQLException {
     // TODO: Detect changes to metadata, which will require schema updates
     SchemaBuilder builder = SchemaBuilder.struct().name(tableName);
     for (int col = 1; col <= metadata.getColumnCount(); col++) {
-      addFieldSchema(metadata, col, builder, mapNumerics);
+
+      addFieldSchema(metadata, col, columnDefaults, builder, mapNumerics);
     }
     return builder.build();
   }
@@ -72,8 +74,14 @@ public class DataConverter {
     return struct;
   }
 
+  private static String whitelistDefaultValue(String defaultValue) {
+    if (defaultValue == null) return null;
+    if (defaultValue.toLowerCase().startsWith("autoincrement")) return null;
+    return defaultValue;
+  }
 
   private static void addFieldSchema(ResultSetMetaData metadata, int col,
+                                     Map<String, String> columnDefaults,
                                      SchemaBuilder builder, boolean mapNumerics)
       throws SQLException {
     // Label is what the query requested the column name be using an "AS" clause, name is the
@@ -83,12 +91,17 @@ public class DataConverter {
     String fieldName = label != null && !label.isEmpty() ? label : name;
 
     int sqlType = metadata.getColumnType(col);
+
+    String defaultValue = whitelistDefaultValue(columnDefaults.get(name));
+    boolean hasDefault = (defaultValue != null);
+
     boolean optional = false;
     if (metadata.isNullable(col) == ResultSetMetaData.columnNullable ||
         metadata.isNullable(col) == ResultSetMetaData.columnNullableUnknown) {
       optional = true;
     }
 
+    Schema schema;
     switch (sqlType) {
       case Types.NULL: {
         log.warn("JDBC type {} not currently supported", sqlType);
@@ -96,26 +109,38 @@ public class DataConverter {
       }
 
       case Types.BOOLEAN: {
-        if (optional) {
-          builder.field(fieldName, Schema.OPTIONAL_BOOLEAN_SCHEMA);
+        if (hasDefault) {
+          boolean castedDefault = Boolean.parseBoolean(defaultValue);
+          schema = SchemaBuilder.bool().defaultValue(castedDefault).build();
         } else {
-          builder.field(fieldName, Schema.BOOLEAN_SCHEMA);
+          schema = (optional) ? Schema.OPTIONAL_BOOLEAN_SCHEMA : Schema.BOOLEAN_SCHEMA;
         }
+        builder.field(fieldName, schema);
         break;
       }
 
       // ints <= 8 bits
       case Types.BIT: {
-        if (optional) {
-          builder.field(fieldName, Schema.OPTIONAL_INT8_SCHEMA);
+        if (hasDefault) {
+          byte castedDefault = Byte.parseByte(defaultValue);
+          schema = SchemaBuilder.int8().defaultValue(castedDefault).build();
         } else {
-          builder.field(fieldName, Schema.INT8_SCHEMA);
+          schema = (optional) ? Schema.OPTIONAL_INT8_SCHEMA : Schema.INT8_SCHEMA;
         }
+        builder.field(fieldName, schema);
         break;
       }
 
       case Types.TINYINT: {
-        if (optional) {
+        if (hasDefault) {
+          if (metadata.isSigned(col)) {
+            short castedDefault = Short.parseShort(defaultValue);
+            builder.field(fieldName, SchemaBuilder.int8().defaultValue(castedDefault).build());
+          } else {
+            int castedDefault = Integer.parseInt(defaultValue);
+            builder.field(fieldName, SchemaBuilder.int16().defaultValue(castedDefault).build());
+          }
+        } else if (optional) {
           if (metadata.isSigned(col)) {
             builder.field(fieldName, Schema.OPTIONAL_INT8_SCHEMA);
           } else {
@@ -133,7 +158,15 @@ public class DataConverter {
 
       // 16 bit ints
       case Types.SMALLINT: {
-        if (optional) {
+        if (hasDefault) {
+          if (metadata.isSigned(col)) {
+            short parsedDefault = Short.parseShort(defaultValue);
+            builder.field(fieldName, SchemaBuilder.int16().defaultValue(parsedDefault).build());
+          } else {
+            int parsedDefault = Integer.parseInt(defaultValue);
+            builder.field(fieldName, SchemaBuilder.int32().defaultValue(parsedDefault).build());
+          }
+        } else if (optional) {
           if (metadata.isSigned(col)) {
             builder.field(fieldName, Schema.OPTIONAL_INT16_SCHEMA);
           } else {
@@ -151,7 +184,15 @@ public class DataConverter {
 
       // 32 bit ints
       case Types.INTEGER: {
-        if (optional) {
+        if (hasDefault) {
+          if (metadata.isSigned(col)) {
+            int parsedDefault = Integer.parseInt(defaultValue);
+            builder.field(fieldName, SchemaBuilder.int32().defaultValue(parsedDefault).build());
+          } else {
+            long parsedDefault = Long.parseLong(defaultValue);
+            builder.field(fieldName, SchemaBuilder.int64().defaultValue(parsedDefault).build());
+          }
+        } else if (optional) {
           if (metadata.isSigned(col)) {
             builder.field(fieldName, Schema.OPTIONAL_INT32_SCHEMA);
           } else {
@@ -169,21 +210,25 @@ public class DataConverter {
 
       // 64 bit ints
       case Types.BIGINT: {
-        if (optional) {
-          builder.field(fieldName, Schema.OPTIONAL_INT64_SCHEMA);
+        if (hasDefault) {
+          long parsedDefault = Long.parseLong(defaultValue);
+          schema = SchemaBuilder.int64().defaultValue(parsedDefault).build();
         } else {
-          builder.field(fieldName, Schema.INT64_SCHEMA);
+          schema = (optional) ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA;
         }
+        builder.field(fieldName, schema);
         break;
       }
 
       // REAL is a single precision floating point value, i.e. a Java float
       case Types.REAL: {
-        if (optional) {
-          builder.field(fieldName, Schema.OPTIONAL_FLOAT32_SCHEMA);
+        if (hasDefault) {
+          float parsedDefault = Float.parseFloat(defaultValue);
+          schema = SchemaBuilder.float32().defaultValue(parsedDefault).build();
         } else {
-          builder.field(fieldName, Schema.FLOAT32_SCHEMA);
+          schema = (optional) ? Schema.OPTIONAL_FLOAT32_SCHEMA : Schema.FLOAT32_SCHEMA;
         }
+        builder.field(fieldName, schema);
         break;
       }
 
@@ -191,11 +236,13 @@ public class DataConverter {
       // for single precision
       case Types.FLOAT:
       case Types.DOUBLE: {
-        if (optional) {
-          builder.field(fieldName, Schema.OPTIONAL_FLOAT64_SCHEMA);
+        if (hasDefault) {
+          double parsedDefault = Double.parseDouble(defaultValue);
+          schema = SchemaBuilder.float64().defaultValue(parsedDefault).build();
         } else {
-          builder.field(fieldName, Schema.FLOAT64_SCHEMA);
+          schema = (optional) ? Schema.OPTIONAL_FLOAT64_SCHEMA : Schema.FLOAT64_SCHEMA;
         }
+        builder.field(fieldName, schema);
         break;
       }
 
@@ -203,25 +250,41 @@ public class DataConverter {
         if (mapNumerics) {
           int precision = metadata.getPrecision(col);
           if (metadata.getScale(col) == 0 && precision < 19) { // integer
-            Schema schema;
             if (precision > 9) {
-              schema = (optional) ? Schema.OPTIONAL_INT64_SCHEMA :
-                      Schema.INT64_SCHEMA;
+              if (hasDefault) {
+                long parsedDefault = Long.parseLong(defaultValue);
+                schema = SchemaBuilder.int64().defaultValue(parsedDefault).build();
+              } else {
+                schema = (optional) ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA;
+              }
             } else if (precision > 4) {
-              schema = (optional) ? Schema.OPTIONAL_INT32_SCHEMA :
-                      Schema.INT32_SCHEMA;
+              if (hasDefault) {
+                int parsedDefault = Integer.parseInt(defaultValue);
+                schema = SchemaBuilder.int32().defaultValue(parsedDefault).build();
+              } else {
+                schema = (optional) ? Schema.OPTIONAL_INT32_SCHEMA : Schema.INT32_SCHEMA;
+              }
             } else if (precision > 2) {
-              schema = (optional) ? Schema.OPTIONAL_INT16_SCHEMA :
-                      Schema.INT16_SCHEMA;
+              if (hasDefault) {
+                short parsedDefault = Short.parseShort(defaultValue);
+                schema = SchemaBuilder.int16().defaultValue(parsedDefault).build();
+              } else {
+                schema = (optional) ? Schema.OPTIONAL_INT16_SCHEMA : Schema.INT16_SCHEMA;
+              }
             } else {
-              schema = (optional) ? Schema.OPTIONAL_INT8_SCHEMA :
-                      Schema.INT8_SCHEMA;
+              if (hasDefault) {
+                byte parsedDefault = Byte.parseByte(defaultValue);
+                schema = SchemaBuilder.int8().defaultValue(parsedDefault).build();
+              } else {
+                schema = (optional) ? Schema.OPTIONAL_INT8_SCHEMA : Schema.INT8_SCHEMA;
+              }
             }
             builder.field(fieldName, schema);
             break;
           }
         }
 
+      //TODO: ???
       case Types.DECIMAL: {
         int scale = metadata.getScale(col);
         if (scale == -127) //NUMBER without precision defined for OracleDB
@@ -230,6 +293,7 @@ public class DataConverter {
         if (optional) {
           fieldBuilder.optional();
         }
+
         builder.field(fieldName, fieldBuilder.build());
         break;
       }
@@ -246,11 +310,12 @@ public class DataConverter {
       case Types.SQLXML: {
         // Some of these types will have fixed size, but we drop this from the schema conversion
         // since only fixed byte arrays can have a fixed size
-        if (optional) {
-          builder.field(fieldName, Schema.OPTIONAL_STRING_SCHEMA);
+        if (hasDefault) {
+          schema = SchemaBuilder.string().defaultValue(defaultValue).build();
         } else {
-          builder.field(fieldName, Schema.STRING_SCHEMA);
+          schema = (optional) ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA;
         }
+        builder.field(fieldName, schema);
         break;
       }
 
@@ -265,13 +330,22 @@ public class DataConverter {
         } else {
           builder.field(fieldName, Schema.BYTES_SCHEMA);
         }
+//        if (hasDefault) {
+////          byte parsedDefault = Byte.parseByte(defaultValue);
+//          schema = SchemaBuilder.bytes().defaultValue(defaultValue).build();
+//        } else {
+//          schema = (optional) ? Schema.OPTIONAL_BYTES_SCHEMA : Schema.BYTES_SCHEMA;
+//        }
+//        builder.field(fieldName, schema);
         break;
       }
 
       // Date is day + moth + year
       case Types.DATE: {
         SchemaBuilder dateSchemaBuilder = Date.builder();
-        if (optional) {
+        if (hasDefault) {
+          dateSchemaBuilder.defaultValue(java.sql.Date.valueOf(defaultValue.replace("'", "")));
+        } else if (optional) {
           dateSchemaBuilder.optional();
         }
         builder.field(fieldName, dateSchemaBuilder.build());
@@ -281,7 +355,9 @@ public class DataConverter {
       // Time is a time of day -- hour, minute, seconds, nanoseconds
       case Types.TIME: {
         SchemaBuilder timeSchemaBuilder = Time.builder();
-        if (optional) {
+        if (hasDefault) {
+          timeSchemaBuilder.defaultValue(java.sql.Time.valueOf(defaultValue.replace("'", "")));
+        } else if (optional) {
           timeSchemaBuilder.optional();
         }
         builder.field(fieldName, timeSchemaBuilder.build());
@@ -291,7 +367,9 @@ public class DataConverter {
       // Timestamp is a date + time
       case Types.TIMESTAMP: {
         SchemaBuilder tsSchemaBuilder = Timestamp.builder();
-        if (optional) {
+        if (hasDefault) {
+          tsSchemaBuilder.defaultValue(java.sql.Timestamp.valueOf(defaultValue.replace("'", "")));
+        } else if (optional) {
           tsSchemaBuilder.optional();
         }
         builder.field(fieldName, tsSchemaBuilder.build());

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -18,11 +18,13 @@ package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
-
+import java.util.Map;
+import java.util.HashMap;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.ResultSetMetaData;
 
 /**
  * TableQuerier executes queries against a specific table. Implementations handle different types
@@ -81,8 +83,21 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   public void maybeStartQuery(Connection db) throws SQLException {
     if (resultSet == null) {
       stmt = getOrCreatePreparedStatement(db);
+
       resultSet = executeQuery();
-      schema = DataConverter.convertSchema(name, resultSet.getMetaData(), mapNumerics);
+      ResultSetMetaData qr = resultSet.getMetaData();
+      ResultSet rs = db.getMetaData().getColumns(db.getCatalog(), db.getSchema(), name, null);
+
+      Map defaults = new HashMap<String, String>();
+      while (rs.next()) {
+        String columnName = rs.getString("COLUMN_NAME");
+        String defaultValue = rs.getString("COLUMN_DEF");
+        if (null != defaultValue) {
+          defaults.put(columnName, defaultValue);
+        }
+      }
+
+      schema = DataConverter.convertSchema(name, qr, defaults, mapNumerics);
     }
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -16,14 +16,8 @@
 
 package io.confluent.connect.jdbc.source;
 
-import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.data.Decimal;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.*;
 import org.apache.kafka.connect.data.Schema.Type;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.data.Time;
-import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
@@ -71,6 +65,11 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
+  public void testDefaultBoolean() throws Exception {
+    typeConversion("BOOLEAN", false, false, SchemaBuilder.bool().defaultValue(true).build(), false, "true");
+  }
+
+  @Test
   public void testSmallInt() throws Exception {
     typeConversion("SMALLINT", false, 1, Schema.INT16_SCHEMA, (short) 1);
   }
@@ -79,6 +78,11 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   public void testNullableSmallInt() throws Exception {
     typeConversion("SMALLINT", true, 1, Schema.OPTIONAL_INT16_SCHEMA, (short) 1);
     typeConversion("SMALLINT", true, null, Schema.OPTIONAL_INT16_SCHEMA, null);
+  }
+
+  @Test
+  public void testDefaultSmallInt() throws Exception {
+    typeConversion("SMALLINT", false, 1, SchemaBuilder.int16().defaultValue((short) 1).build(), (short) 1, "1");
   }
 
   @Test
@@ -93,6 +97,11 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
+  public void testDefaultInt() throws Exception {
+    typeConversion("INTEGER", false, 1, SchemaBuilder.int32().defaultValue(1).build(), 1, "1");
+  }
+
+  @Test
   public void testBigInt() throws Exception {
     typeConversion("BIGINT", false, Long.MAX_VALUE, Schema.INT64_SCHEMA, Long.MAX_VALUE);
   }
@@ -101,6 +110,11 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   public void testNullableBigInt() throws Exception {
     typeConversion("BIGINT", true, Long.MAX_VALUE, Schema.OPTIONAL_INT64_SCHEMA, Long.MAX_VALUE);
     typeConversion("BIGINT", true, null, Schema.OPTIONAL_INT64_SCHEMA, null);
+  }
+
+  @Test
+  public void testDefaultBigInt() throws Exception {
+    typeConversion("BIGINT", true, 1, SchemaBuilder.int64().defaultValue((long) 1).build(), (long) 1, "1");
   }
 
   @Test
@@ -115,6 +129,11 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
+  public void testDefaultReal() throws Exception {
+    typeConversion("REAL", false, 1.1, SchemaBuilder.float32().defaultValue((float) 1).build(), (float) 1.1, "1");
+  }
+
+  @Test
   public void testDouble() throws Exception {
     typeConversion("DOUBLE", false, 1, Schema.FLOAT64_SCHEMA, 1.0);
   }
@@ -123,6 +142,11 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   public void testNullableDouble() throws Exception {
     typeConversion("DOUBLE", true, 1, Schema.OPTIONAL_FLOAT64_SCHEMA, 1.0);
     typeConversion("DOUBLE", true, null, Schema.OPTIONAL_FLOAT64_SCHEMA, null);
+  }
+
+  @Test
+  public void testDefaultDouble() throws Exception {
+    typeConversion("DOUBLE", false, 1.1, SchemaBuilder.float64().defaultValue( 1.1).build(), 1.1, "1.1");
   }
 
   @Test
@@ -139,6 +163,11 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
+  public void testDefaultChar() throws Exception {
+    typeConversion("CHAR(5)", false, "a", SchemaBuilder.string().defaultValue("'b'").build(), "a    ", "'b'");
+  }
+
+  @Test
   public void testVarChar() throws Exception {
     // Converted to string, so fixed size not checked
     typeConversion("VARCHAR(5)", false, "a", Schema.STRING_SCHEMA, "a");
@@ -149,6 +178,11 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
     // Converted to string, so fixed size not checked
     typeConversion("VARCHAR(5)", true, "a", Schema.OPTIONAL_STRING_SCHEMA, "a");
     typeConversion("VARCHAR(5)", true, null, Schema.OPTIONAL_STRING_SCHEMA, null);
+  }
+
+  @Test
+  public void testDefaultVarChar() throws Exception {
+    typeConversion("VARCHAR(5)", false, "b", SchemaBuilder.string().defaultValue("'a'").build(), "b", "'a'");
   }
 
   @Test
@@ -247,6 +281,15 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
+  public void testDefaultDate() throws Exception {
+    GregorianCalendar expected = new GregorianCalendar(2017, Calendar.JANUARY, 01, 0, 0, 0);
+    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    java.sql.Date defaultValue = java.sql.Date.valueOf("1990-01-01");
+    typeConversion("DATE", false, "2017-01-01",
+            Date.builder().defaultValue(defaultValue).build(), expected.getTime(), "'1990-01-01'");
+  }
+
+  @Test
   public void testTime() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1970, Calendar.JANUARY, 1, 23, 3, 20);
     expected.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -265,6 +308,15 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
     typeConversion("TIME", true, null,
                    Time.builder().optional().build(),
                    null);
+  }
+
+  @Test
+  public void testDefaultTime() throws Exception {
+    GregorianCalendar expected = new GregorianCalendar(1970, Calendar.JANUARY, 1, 23, 3, 20);
+    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    java.sql.Time defaultValue = java.sql.Time.valueOf("00:00:00");
+    typeConversion("TIME", true, "23:03:20",
+            Time.builder().defaultValue(defaultValue).build(), expected.getTime(),  "'00:00:00'");
   }
 
   @Test
@@ -288,6 +340,15 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
                    null);
   }
 
+  @Test
+  public void testDefaultTimestamp() throws Exception {
+    GregorianCalendar expected = new GregorianCalendar(1977, Calendar.FEBRUARY, 13, 23, 3, 20);
+    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    java.sql.Timestamp defaultValue = java.sql.Timestamp.valueOf("2000-01-01 00:00:00");
+    typeConversion("TIMESTAMP", false, "1977-02-13 23:03:20",
+            Timestamp.builder().defaultValue(defaultValue).build(), expected.getTime(), "'2000-01-01 00:00:00'");
+  }
+
   // Derby has an XML type, but the JDBC driver doesn't implement any of the type bindings,
   // returning strings instead, so the XML type is not tested here
 
@@ -298,6 +359,21 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
     if (!nullable) {
       sqlColumnSpec += " NOT NULL";
     }
+    db.createTable(SINGLE_TABLE_NAME, "id", sqlColumnSpec);
+    db.insert(SINGLE_TABLE_NAME, "id", sqlValue);
+    List<SourceRecord> records = task.poll();
+    validateRecords(records, convertedSchema, convertedValue);
+    db.dropTable(SINGLE_TABLE_NAME);
+  }
+
+  private void typeConversion(String sqlType, boolean nullable,
+                              Object sqlValue, Schema convertedSchema,
+                              Object convertedValue, String defaultValue) throws Exception {
+    String sqlColumnSpec = sqlType;
+    if (!nullable) {
+      sqlColumnSpec += " NOT NULL";
+    }
+    sqlColumnSpec += " DEFAULT " + defaultValue;
     db.createTable(SINGLE_TABLE_NAME, "id", sqlColumnSpec);
     db.insert(SINGLE_TABLE_NAME, "id", sqlValue);
     List<SourceRecord> records = task.poll();


### PR DESCRIPTION
Currently confluent's jdbc connect solution will not pick up non null default values from source db's, which when combined with the schema registry causes non breaking changes to be considered breaking.

This forks confluents kafka connect jdbc project and adds ability for source connector to pick up default values from JDBC table definitions. 

Avro will not accept computed default values. The only likely one I've seen so far is "AUTOINCREMENT: start 1 increment 1", which will be blocked from populating our output schema's default field. Other than that, a column's constant default value as defined in the DDL will be injected into the data's schema.