### PR TITLE
Data 4980 Use UTC_TIMESTAMP to get latest timestamp from MYSQL db

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
@@ -191,6 +191,8 @@ public class JdbcUtils {
       query = "select CURRENT_TIMESTAMP from dual";
     else if ("Apache Derby".equals(dbProduct))
       query = "values(CURRENT_TIMESTAMP)";
+    else if (dbProduct.contains("MySQL"))
+      query = "select UTC_TIMESTAMP;";
     else
       query = "select CURRENT_TIMESTAMP;";
 


### PR DESCRIPTION
# Summary
Use UTC_TIMESTAMP instead of CURRENT_TIMESTAMP to determine what time is used for the delta query from source to Kafka. 
# Details
This is required as FADMIN is configured to use EST as its timezone, however the data is stored in UTC. The result of `select CURRENT_TIMESTAMP;` on FADMIN is thus, in EST.
This change will affect all sources that will be added into Kafka Connect. Most Rails apps already have the same timezone behaviour as FADMIN, so those should not be affected by this change.
However any app that uses MySQL but stores its in EST may have unintended consequences.